### PR TITLE
Requirements for minimum PHP version and PHP extensions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,11 @@
             "Zotapay\\": "lib/"
         }
     },
-    "require": {},
+    "require": {
+        "php": ">=7.2",
+        "ext-curl": "*",
+        "ext-json": "*"
+    },
     "require-dev": {
         "squizlabs/php_codesniffer": "3.5.5",
         "phpunit/phpunit": "^9.2"


### PR DESCRIPTION
Requirement for minimum PHP version 7.2.

PHP extensions version not defined because most of the extensions are visible as the PHP version. 

`composer show --platform` shows the available extensions

Defining cURL version 7.34.0 for support if TLS v1.2 as requirement is not possible. But cURL 7.34.0 is released on Dec 17 2013 and current version in PHP 7.3.19 for example is 7.52.1 so we assume that is OK.


 