### PR TITLE
Pipeline dependencies updates

### DIFF
--- a/.github/workflows/php-quicktest.yml
+++ b/.github/workflows/php-quicktest.yml
@@ -54,7 +54,7 @@ jobs:
       run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/.github/workflows/php-quicktest.yml
+++ b/.github/workflows/php-quicktest.yml
@@ -45,7 +45,7 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-
 
     - name: Install dependencies
-      run: composer install --no-suggest --prefer-dist --optimize-autoloader
+      run: composer install --prefer-dist --optimize-autoloader
 
     - name: Setup problem matchers for PHPUnit
       run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"

--- a/.github/workflows/php-quicktest.yml
+++ b/.github/workflows/php-quicktest.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl, dom, fileinfo, curl
         ini-values: post_max_size=256M
         coverage: xdebug
@@ -38,7 +38,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.composercache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Removed deprecated option "--no-suggest" from composer command in php_quicktest to test the workflow. If not works will try to add 'composer update' step.